### PR TITLE
Add ggrepel dependency package to Imports list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Imports:
     readr,
     magrittr,
     ggplot2,
+    ggrepel,
     cowplot,
     data.table,
     Matrix


### PR DESCRIPTION
Closes #11 

You have used the ggrepel package so this needs to be listed in either the Imports or Suggests list in the DESCRIPTION file, which this PR simply adds.

The current work around is that users need to install ggrepel before installing this package (but that shouldn't really be necessary).

thanks
  Tom